### PR TITLE
load respondent groups to device storage

### DIFF
--- a/lib/core/usecases/need_insert_respondent_data_usecase.dart
+++ b/lib/core/usecases/need_insert_respondent_data_usecase.dart
@@ -2,4 +2,5 @@ import 'package:survey_frontend/core/models/need_insert_respondent_data_result.d
 
 abstract class NeedInsertRespondentDataUseCase{
   Future<NeedInsertRespondentDataResult> needInsertRespondentData();
+  Future<void> update(String respondentId);
 }

--- a/lib/core/usecases/need_insert_respondent_data_usecase_impl.dart
+++ b/lib/core/usecases/need_insert_respondent_data_usecase_impl.dart
@@ -1,6 +1,7 @@
 import 'package:get_storage/get_storage.dart';
 import 'package:survey_frontend/core/models/need_insert_respondent_data_result.dart';
 import 'package:survey_frontend/core/usecases/need_insert_respondent_data_usecase.dart';
+import 'package:survey_frontend/domain/external_services/api_response.dart';
 import 'package:survey_frontend/domain/external_services/initial_survey_service.dart';
 import 'package:survey_frontend/domain/external_services/respondent_group_service.dart';
 
@@ -18,6 +19,7 @@ class NeedInsertRespondentDataUseCaseImpl
     var respondentData = _storage.read("respondentData");
 
     if (respondentData != null) {
+      await update(respondentData['id']);
       return NeedInsertRespondentDataResult.noNeed;
     }
 
@@ -57,6 +59,16 @@ class NeedInsertRespondentDataUseCaseImpl
 
     if (groupsResult.statusCode == 200) {
       await _storage.write('groups', groupsResult.body);
+    }
+  }
+
+  @override
+  Future<void> update(String respondentId) async {
+    final results = await Future.wait([_trySaveResopndentsGroups(respondentId), _respondentDataService.getMyResponse()]);
+    final respondentDataResult = results[1] as APIResponse<Map<String, dynamic>>;
+
+    if (respondentDataResult.statusCode == 200){
+      await _storage.write('respondentData', respondentDataResult.body);
     }
   }
 }

--- a/lib/core/usecases/read_respondent_groups_usecase.dart
+++ b/lib/core/usecases/read_respondent_groups_usecase.dart
@@ -1,0 +1,29 @@
+import 'package:get_storage/get_storage.dart';
+import 'package:survey_frontend/domain/models/respondent_group_dto.dart';
+
+abstract class ReadResopndentGroupdUseCase {
+  Future<List<RespondentGroupDto>> getAll();
+}
+
+class ReadResopndentGroupdUseCaseImpl implements ReadResopndentGroupdUseCase{
+  final GetStorage _storage;
+
+  ReadResopndentGroupdUseCaseImpl(this._storage);
+
+  @override
+  Future<List<RespondentGroupDto>> getAll() {
+    final result = _storage.read<List<dynamic>>('groups');
+    if (result == null){
+      return Future.value([]);
+    }
+
+    return Future.value(result.map((e){
+      if (e.runtimeType == RespondentGroupDto){
+        return e as RespondentGroupDto;
+      }
+
+      return RespondentGroupDto.fromJson(e);
+    }).toList());
+  }
+
+}

--- a/lib/data/datasources/respondent_group_service_impl.dart
+++ b/lib/data/datasources/respondent_group_service_impl.dart
@@ -5,7 +5,7 @@ import 'package:survey_frontend/domain/models/respondent_group_dto.dart';
 
 class RespondentGroupServiceImpl extends APIServiceBase
     implements RespondentGroupService {
-  RespondentGroupServiceImpl(super.dio);
+  RespondentGroupServiceImpl(super.dio, {required super.tokenProvider});
 
   @override
   Future<APIResponse<List<RespondentGroupDto>>> getAllForRespondent(

--- a/lib/domain/models/create_survey_response_dto.dart
+++ b/lib/domain/models/create_survey_response_dto.dart
@@ -8,7 +8,7 @@ class CreateSurveyResponseDto {
   final String surveyId;
   final String startDate;
   late final String finishDate;
-  final List<CreateQuestionAnswerDto> answers;
+  List<CreateQuestionAnswerDto> answers;
 
   CreateSurveyResponseDto(
       {required this.surveyId, required this.startDate, required this.answers});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,6 @@ import 'package:survey_frontend/presentation/screens/survey/survey_start_screen.
 import 'package:survey_frontend/presentation/screens/welcome_screen.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:survey_frontend/presentation/static/routes.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class StaticVariables {
   static String lang = 'en';

--- a/lib/presentation/bindings/home_bindings.dart
+++ b/lib/presentation/bindings/home_bindings.dart
@@ -14,9 +14,7 @@ class HomeBindings extends Bindings {
         tokenProvider: Get.find()));
     Get.lazyPut<CreateQuestionAnswerDtoFactory>(
         () => CreateQuestionAnswerDtoFactoryImpl());
-    Get.lazyPut<RespondentGroupService>(
-        () => RespondentGroupServiceImpl(Get.find()));
     Get.lazyPut<HomeController>(() => HomeController(Get.find(), Get.find(),
-        Get.find(), Get.find(), Get.find(), Get.find(), Get.find(), Get.find()));
+        Get.find(), Get.find(), Get.find(), Get.find()));
   }
 }

--- a/lib/presentation/bindings/initial_bindings.dart
+++ b/lib/presentation/bindings/initial_bindings.dart
@@ -67,7 +67,7 @@ class InitialBindings extends Bindings {
     Get.lazyPut<SurveyParticipationService>(
         () => SurveyParticipationServiceImpl(Get.find()));
     Get.lazyPut<RespondentGroupService>(
-        () => RespondentGroupServiceImpl(Get.find()));
+        () => RespondentGroupServiceImpl(Get.find(), tokenProvider: Get.find<TokenProvider>()));
     Get.put<NeedInsertRespondentDataUseCase>(
         NeedInsertRespondentDataUseCaseImpl(
             Get.find(), Get.find(), Get.find()));

--- a/lib/presentation/bindings/initial_bindings.dart
+++ b/lib/presentation/bindings/initial_bindings.dart
@@ -4,6 +4,7 @@ import 'package:get_storage/get_storage.dart';
 import 'package:location/location.dart';
 import 'package:survey_frontend/core/usecases/need_insert_respondent_data_usecase.dart';
 import 'package:survey_frontend/core/usecases/need_insert_respondent_data_usecase_impl.dart';
+import 'package:survey_frontend/core/usecases/read_respondent_groups_usecase.dart';
 import 'package:survey_frontend/core/usecases/read_sensors_data_usecase.dart';
 import 'package:survey_frontend/core/usecases/send_sensors_data_usecase.dart';
 import 'package:survey_frontend/core/usecases/survey_images_usecase.dart';
@@ -16,6 +17,7 @@ import 'package:survey_frontend/data/datasources/local/survey_participation_serv
 import 'package:survey_frontend/data/datasources/location_service_impl.dart';
 import 'package:survey_frontend/data/datasources/login_service_impl.dart';
 import 'package:survey_frontend/data/datasources/respondent_data_service_impl.dart';
+import 'package:survey_frontend/data/datasources/respondent_group_service_impl.dart';
 import 'package:survey_frontend/data/datasources/sensors_data_service_impl.dart';
 import 'package:survey_frontend/data/datasources/survey_service_impl.dart';
 import 'package:survey_frontend/data/models/sensor_kind.dart';
@@ -23,6 +25,7 @@ import 'package:survey_frontend/domain/external_services/initial_survey_service.
 import 'package:survey_frontend/domain/external_services/location_service.dart';
 import 'package:survey_frontend/domain/external_services/login_service.dart';
 import 'package:survey_frontend/domain/external_services/respondent_date_service.dart';
+import 'package:survey_frontend/domain/external_services/respondent_group_service.dart';
 import 'package:survey_frontend/domain/external_services/sensors_data_service.dart';
 import 'package:survey_frontend/domain/external_services/survey_service.dart';
 import 'package:survey_frontend/domain/local_services/survey_participation_service.dart';
@@ -53,7 +56,8 @@ class InitialBindings extends Bindings {
     Get.lazyPut(() => RespondentDataController());
     Get.lazyPut(() => ArchivedSurveysController());
     Get.create<SurveyService>(() => SurveyServiceImpl(Get.find()));
-    Get.create<SurveyQuestionController>(() => SurveyQuestionController(Get.find()));
+    Get.create<SurveyQuestionController>(
+        () => SurveyQuestionController(Get.find()));
 
     TokenProvider tp = TokenProviderImpl(Get.find());
     Get.put<TokenProvider>(tp);
@@ -62,30 +66,36 @@ class InitialBindings extends Bindings {
         InitialSurveyServiceImpl(Get.find(), tokenProvider: Get.find()));
     Get.lazyPut<SurveyParticipationService>(
         () => SurveyParticipationServiceImpl(Get.find()));
+    Get.lazyPut<RespondentGroupService>(
+        () => RespondentGroupServiceImpl(Get.find()));
     Get.put<NeedInsertRespondentDataUseCase>(
-        NeedInsertRespondentDataUseCaseImpl(Get.find(), Get.find()));
+        NeedInsertRespondentDataUseCaseImpl(
+            Get.find(), Get.find(), Get.find()));
     Get.put<TokenValidityChecker>(TokenValidityCheckerImpl());
     Get.lazyPut<RespondentDataService>(() => RespondentDataServiceImpl(
         Get.find(),
         tokenProvider: Get.find<TokenProvider>()));
     Get.put(DatabaseHelper());
-    Get.put<SurveyNotificationUseCase>(SurveyNotificationUseCaseImpl(Get.find()));
+    Get.put<SurveyNotificationUseCase>(
+        SurveyNotificationUseCaseImpl(Get.find()));
     Get.put<SensorsDataService>(
         SensorsDataServiceImpl(Get.find(), tokenProvider: Get.find()));
     Get.put<SendSensorsDataUsecase>(
         SendSensorsDataUsecaseImpl(Get.find(), Get.find()));
     Get.put<ReadSensorsDataUsecase>(ReadXiaomiSensorsDataUsecase(),
         tag: SensorKind.xiaomi);
-    Get.put<LocalizationService>(LocalizationServiceImpl(Get.find(), tokenProvider: Get.find<TokenProvider>()));
+    Get.put<LocalizationService>(LocalizationServiceImpl(Get.find(),
+        tokenProvider: Get.find<TokenProvider>()));
     Get.put<SurveyImagesUseCase>(SurveyImagesUseCaseImpl(Get.find()));
-
+    Get.put<ReadResopndentGroupdUseCase>(
+        ReadResopndentGroupdUseCaseImpl(Get.find()));
   }
 
   Dio _getDio(GetStorage storage) {
     var dio = Dio();
     final apiUrl = storage.read<String>('apiUrl');
     if (apiUrl != null) {
-      dio.options.baseUrl = apiUrl; 
+      dio.options.baseUrl = apiUrl;
     }
     dio.options.headers["Accept-Lang"] = StaticVariables.lang;
     dio.options.connectTimeout = const Duration(seconds: 30);

--- a/lib/presentation/controllers/loading_controller.dart
+++ b/lib/presentation/controllers/loading_controller.dart
@@ -34,6 +34,7 @@ class LoadingController extends ControllerBase {
     var respondentData = _storage.read<dynamic>("respondentData");    
 
     if (respondentData != null) {
+      _needInsertRespondentDataUseCase.update(respondentData['id']);
       goToNamedPrivacySave(Routes.home);
       return;
     }

--- a/lib/presentation/controllers/profile_controller.dart
+++ b/lib/presentation/controllers/profile_controller.dart
@@ -9,6 +9,7 @@ class ProfileController extends ControllerBase {
   late List<InitialSurveyQuestion> initialSurveyQuestions;
 
   ProfileController(GetStorage storage)
+  //TODO: crashes, where there is no initial survey
       : respondentData = storage.read("respondentData")! {
     initialSurveyQuestions = (storage
         .read<List<dynamic>>('initialSurvey') ?? [])

--- a/lib/presentation/controllers/survey_end_controller.dart
+++ b/lib/presentation/controllers/survey_end_controller.dart
@@ -56,6 +56,7 @@ class SurveyEndController extends ControllerBase {
 
   Future<SurveyParticipationDto?> _submitToServer() async {
     try {
+      _clearDto();
       dto.finishDate = DateTime.now().toUtc().toIso8601String();
       final apiResponse = await _surveyService.submitResponse(dto);
       return apiResponse.body;
@@ -65,6 +66,16 @@ class SurveyEndController extends ControllerBase {
       //TODO: log the error
       return null;
     }
+  }
+
+  void _clearDto() {
+    dto.answers = dto.answers.where((e) {
+      //TODO: extend this, when we have a new text input question type
+      return e.yesNoAnswer != null ||
+          e.numericAnswer != null ||
+          (e.selectedOptions != null &&
+              e.selectedOptions!.every((e) => e.optionId != null));
+    }).toList();
   }
 
   void readGetArgs() {

--- a/lib/presentation/screens/survey/widgets/discrete_single_option_type_question.dart
+++ b/lib/presentation/screens/survey/widgets/discrete_single_option_type_question.dart
@@ -26,34 +26,28 @@ class _DiscreteSingleOptionTypeQuestionState
   @override
   Widget build(BuildContext context) {
     return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Text(widget.fromLabel ?? ''),
-            Text(widget.toLabel ?? ''),
-          ],
-        ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: List<Widget>.generate(widget.to - widget.from + 1, (index) {
-            final value = widget.from + index;
-            return Column(
-              children: [
-                Text(value.toString()),
-                Radio(
-                  value: value,
-                  groupValue: widget.dto.numericAnswer,
-                  onChanged: (val) {
-                    setState(() {
-                      widget.dto.numericAnswer = val;
-                    });
-                  },
-                ),
-              ],
-            );
-          }),
-        ),
+        Text(widget.fromLabel ?? ''),
+        ...List<Widget>.generate(widget.to - widget.from + 1, (index) {
+          final value = widget.from + index;
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(value.toString()),
+              Radio(
+                value: value,
+                groupValue: widget.dto.numericAnswer,
+                onChanged: (val) {
+                  setState(() {
+                    widget.dto.numericAnswer = val;
+                  });
+                },
+              ),
+            ],
+          );
+        }),
+        Text(widget.toLabel ?? ''),
       ],
     );
   }

--- a/lib/presentation/screens/survey/widgets/number_input_type_question.dart
+++ b/lib/presentation/screens/survey/widgets/number_input_type_question.dart
@@ -19,7 +19,7 @@ class _NumberInputTypeQuestion extends State<NumberInputTypeQuestion> {
     return TextFormField(
       autovalidateMode: AutovalidateMode.onUserInteraction,
       decoration: InputDecoration(labelText: getAppLocalizations().enterNumber),
-      keyboardType: TextInputType.number,
+      keyboardType: const TextInputType.numberWithOptions(signed: true),
       validator: (value) {
         if (value == null || value.isEmpty) {
           return getAppLocalizations().pleaseEnterNumber;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -167,7 +167,7 @@ packages:
     source: hosted
     version: "4.10.1"
   collection:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a


### PR DESCRIPTION
Respondents groups are saved in the device storage,  to prepare surveys to be complitable offline. Also, he groups and respondent data are tried to be refreshed on app start.